### PR TITLE
initdbのオプション変更

### DIFF
--- a/.github/workflows/it.yaml
+++ b/.github/workflows/it.yaml
@@ -14,7 +14,7 @@ jobs:
         image: postgres:17
         env:
           POSTGRES_PASSWORD: pwtest
-          POSTGRES_INITDB_ARGS: "--no-locale -E UTF-8"
+          POSTGRES_INITDB_ARGS: "--no-locale -E UTF-8 -A scram-sha-256"
           TZ: Asia/Tokyo
         options: >-
           --health-cmd pg_isready

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       - 127.0.0.1:5432:5432
     environment:
       POSTGRES_PASSWORD: pwdev
-      POSTGRES_INITDB_ARGS: "--no-locale -E UTF-8"
+      POSTGRES_INITDB_ARGS: "--no-locale -E UTF-8 -A scram-sha-256"
       TZ: Asia/Tokyo
     healthcheck:
       test: "pg_isready -U postgres || exit 1"
@@ -26,7 +26,7 @@ services:
     environment:
       POSTGRES_PASSWORD: pwtest
       PGDATA: /dev/shm/pgdata
-      POSTGRES_INITDB_ARGS: "--no-locale -E UTF-8"
+      POSTGRES_INITDB_ARGS: "--no-locale -E UTF-8 -A scram-sha-256"
       TZ: Asia/Tokyo
     healthcheck:
       test: "pg_isready -U postgres || exit 1"


### PR DESCRIPTION
warning対応

```
initdb: warning: enabling "trust" authentication for local connections
initdb: hint: You can change this by editing pg_hba.conf or using the option -A, or --auth-local and --auth-host, the next time you run initdb.
```